### PR TITLE
feat: persist auth session

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,25 +1,44 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
-import { Provider } from 'react-redux';
+import { Provider, useSelector } from 'react-redux';
 import App from './App';
 import { ConfigProvider, App as AntApp } from 'antd';
 import 'antd/dist/reset.css';
 import store from './store';
 
+const Root = () => {
+  const auth = useSelector((state) => state.auth);
+
+  useEffect(() => {
+    if (auth.user && auth.token) {
+      localStorage.setItem(
+        'auth',
+        JSON.stringify({ user: auth.user, token: auth.token })
+      );
+    } else {
+      localStorage.removeItem('auth');
+    }
+  }, [auth]);
+
+  return (
+    <ConfigProvider
+      theme={{
+        token: {
+          colorPrimary: '#1A69AF',
+        },
+      }}
+    >
+      <AntApp>
+        <App />
+      </AntApp>
+    </ConfigProvider>
+  );
+};
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <Provider store={store}>
-      <ConfigProvider
-        theme={{
-          token: {
-            colorPrimary: '#1A69AF', 
-          },
-        }}
-      >
-        <AntApp>
-          <App />
-        </AntApp>
-      </ConfigProvider>
+      <Root />
     </Provider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,10 +1,29 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from './slices/authSlice';
 
+// Cargar estado persistido de localStorage si existe
+const persistedAuth =
+  typeof window !== 'undefined' ? localStorage.getItem('auth') : null;
+const authData = persistedAuth ? JSON.parse(persistedAuth) : null;
+
+const preloadedState = authData
+  ? {
+      auth: {
+        ...authData,
+        loading: false,
+        error: null,
+        formularios: [],
+        formularioLoading: false,
+        formularioError: null
+      }
+    }
+  : undefined;
+
 const store = configureStore({
   reducer: {
     auth: authReducer
   },
+  preloadedState,
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
       serializableCheck: false

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -69,6 +69,10 @@ const authSlice = createSlice({
       state.token = null;
       state.error = null;
       state.formularios = [];
+      // Eliminar credenciales del almacenamiento local
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('auth');
+      }
     },
     clearErrors: (state) => {
       state.error = null;
@@ -102,6 +106,14 @@ const authSlice = createSlice({
         real se debe extraer el token de la respuesta o usar algún mecanismo de autenticación.
         */
         state.token = 'simulated-token'; // En producción, debes obtener el token real de la respuesta
+
+        // Guardar credenciales en el almacenamiento local
+        if (typeof window !== 'undefined') {
+          localStorage.setItem(
+            'auth',
+            JSON.stringify({ user: state.user, token: state.token })
+          );
+        }
       })
       .addCase(loginUser.rejected, (state, action) => {
         state.loading = false;


### PR DESCRIPTION
## Summary
- persist credentials to localStorage on login and clear on logout
- bootstrap store with auth data from localStorage
- sync auth changes to storage via Root component effect

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 86 problems (80 errors, 6 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6893794d44e08333909abe245e4aa820