### PR TITLE
Condiciona React.StrictMode según ambiente

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -35,10 +35,16 @@ const Root = () => {
   );
 };
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <Root />
-    </Provider>
-  </React.StrictMode>,
+const root = ReactDOM.createRoot(document.getElementById('root'));
+
+const app = (
+  <Provider store={store}>
+    <Root />
+  </Provider>
 );
+
+if (import.meta.env.PROD) {
+  root.render(<React.StrictMode>{app}</React.StrictMode>);
+} else {
+  root.render(app);
+}


### PR DESCRIPTION
## Summary
- Renderiza `<React.StrictMode>` solo en producción para evitar efectos dobles en desarrollo

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 84 errors, 6 warnings)*
- `npx vite-node verifyIprus.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6893829ebc208333bcf6515546c22264