### PR TITLE
feat: add payment session cleanup utility

### DIFF
--- a/src/components/ConsultaForm.jsx
+++ b/src/components/ConsultaForm.jsx
@@ -11,6 +11,7 @@ import {
 } from '@ant-design/icons';
 import PaymentModal from './PaymentModal';
 import config from '../config/config';
+import { clearPaymentSession } from '../utils/clearPaymentSession';
 
 const { Title } = Typography;
 const { useBreakpoint } = Grid;
@@ -457,8 +458,8 @@ function ConsultaForm() {
     generateCaptcha();
     setCoactivaIds([]);
 
-    // (Opcional) limpiar la cédula guardada
-    localStorage.removeItem('cedulaConsultada');
+    // Limpiar la información de sesión de pago
+    clearPaymentSession();
   };
 
   const handlePaymentSubmit = async (paymentData) => {
@@ -773,6 +774,7 @@ function ConsultaForm() {
       <PaymentModal
         visible={paymentModalVisible}
         onCancel={() => {
+          clearPaymentSession();
           setPaymentModalVisible(false);
           setProcessUrl(null);
           //setFacturaIds([]);

--- a/src/components/PaymentModal.jsx
+++ b/src/components/PaymentModal.jsx
@@ -3,6 +3,7 @@ import { Modal, Form, Input, Button, Alert, message, Checkbox, Radio } from 'ant
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import config from '../config/config';
+import { clearPaymentSession } from '../utils/clearPaymentSession';
 
 const generarCodigoVerificacion = () => {
   return Math.floor(10000 + Math.random() * 90000).toString();
@@ -38,6 +39,11 @@ const PaymentModal = ({
     correoVerificado: false,
     enviandoCodigo: false,
   });
+
+  const handleCancel = () => {
+    clearPaymentSession();
+    onCancel();
+  };
 
   // Estado para controlar si el botón de pago ha sido presionado
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -383,15 +389,15 @@ const PaymentModal = ({
       <Modal
         title="Datos para el Pago"
         open={visible}
-        onCancel={onCancel}
+        onCancel={handleCancel}
         footer={[
-          <Button key="back" onClick={onCancel}>
+          <Button key="back" onClick={handleCancel}>
             Cancelar
           </Button>,
-          <Button 
-            key="submit" 
-            type="primary" 
-            loading={loading || isSubmitting} 
+          <Button
+            key="submit"
+            type="primary"
+            loading={loading || isSubmitting}
             onClick={handleSubmit}
             disabled={isSubmitting}
           >

--- a/src/components/PaymentStatus.jsx
+++ b/src/components/PaymentStatus.jsx
@@ -3,6 +3,7 @@ import { Card, Spin, Result, Button, Descriptions } from 'antd';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
 import config from '../config/config';
+import { clearPaymentSession } from '../utils/clearPaymentSession';
 
 const translateReason = (reason) => {
   switch (reason) {
@@ -157,13 +158,8 @@ const PaymentStatus = () => {
               setMessage('Estado de pago en proceso');
           }
 
-          // Limpiar localStorage //
-          /* localStorage.removeItem('sessionId');
-          localStorage.removeItem('requestId');
-          localStorage.removeItem('facturaIds');
-          localStorage.removeItem('timeReference');
-          localStorage.removeItem('cedulaConsultada');
-          localStorage.removeItem('idPasarela'); */
+          // Limpiar almacenamiento relacionado con el pago
+          clearPaymentSession();
         } else {
           setStatus('error');
           setMessage('No se encontraron detalles de pago.');

--- a/src/components/Tramites/Dashboard.jsx
+++ b/src/components/Tramites/Dashboard.jsx
@@ -7,6 +7,7 @@ import axios from 'axios';
 import Swal from 'sweetalert2';
 import { loginUser, clearErrors } from '../../store/slices/authSlice';
 import config from '../../config/config';
+import { clearPaymentSession } from '../../utils/clearPaymentSession';
 
 const { Title, Paragraph } = Typography;
 
@@ -72,6 +73,7 @@ const Dashboard = () => {
   // Efecto para manejar la redirección después de un login exitoso
   useEffect(() => {
     const verificarSeisionPago = async () => {
+      clearPaymentSession();
       //VERIFICAR TRANSACCIONES PENDIENTES
       //-------------------------------------------------------------------------------------------------------------------------------
       //-------------------------------------------------------------------------------------------------------------------------------

--- a/src/components/Tramites/Iprus.jsx
+++ b/src/components/Tramites/Iprus.jsx
@@ -7,6 +7,7 @@ import axios from 'axios';
 import config from '../../config/config';
 import Swal from 'sweetalert2';
 import PaymentModal from '../PaymentModal';
+import { clearPaymentSession } from '../../utils/clearPaymentSession';
 
 const { Title, Paragraph, Text } = Typography;
 const { Option } = Select;
@@ -502,6 +503,7 @@ const Iprus = () => {
       <PaymentModal
         visible={paymentModalVisible}
         onCancel={() => {
+          clearPaymentSession();
           setLoadingCertificado(true);
           setPaymentModalVisible(false);
           setProcessUrl(null);

--- a/src/utils/clearPaymentSession.js
+++ b/src/utils/clearPaymentSession.js
@@ -1,0 +1,19 @@
+export function clearPaymentSession() {
+  const paymentKeys = [
+    'cedulaConsultada',
+    'facturaIds',
+    'idPasarela',
+    'requestId',
+    'timeReference',
+    'sessionId',
+  ];
+
+  paymentKeys.forEach((key) => localStorage.removeItem(key));
+
+  // Remove any other keys related to payment sessions
+  Object.keys(localStorage)
+    .filter((key) => key.toLowerCase().includes('payment') || key.toLowerCase().includes('pago'))
+    .forEach((key) => localStorage.removeItem(key));
+}
+
+export default clearPaymentSession;


### PR DESCRIPTION
## Summary
- add shared `clearPaymentSession` helper to remove payment-related keys from storage
- invoke `clearPaymentSession` across payment components for consistent session cleanup

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: ESLint errors)


------
https://chatgpt.com/codex/tasks/task_e_689f5963e4b08333b3c36b72c40e178e