### PR TITLE
chore: use utility to clear payment session

### DIFF
--- a/src/components/PaymentStatus.jsx
+++ b/src/components/PaymentStatus.jsx
@@ -158,12 +158,13 @@ const PaymentStatus = () => {
               setMessage('Estado de pago en proceso');
           }
 
-          // Limpiar almacenamiento relacionado con el pago
-          clearPaymentSession();
         } else {
           setStatus('error');
           setMessage('No se encontraron detalles de pago.');
         }
+
+        // Limpiar almacenamiento relacionado con el pago
+        clearPaymentSession();
       } catch (error) {
         console.error('Error al verificar estado:', error);
         setStatus('error');


### PR DESCRIPTION
## Summary
- clean up payment session using shared utility in `PaymentStatus`

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: see errors above)*

------
https://chatgpt.com/codex/tasks/task_e_689f5c5e66408333b3a191ccaf016f82