### PR TITLE
feat(auth): clear payment session on logout

### DIFF
--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -1,6 +1,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 import config from '../../config/config';
+import { clearPaymentSession } from '../../utils/clearPaymentSession';
 
 // Acción asincrónica para iniciar sesión
 export const loginUser = createAsyncThunk(
@@ -71,6 +72,7 @@ const authSlice = createSlice({
       state.formularios = [];
       // Eliminar credenciales del almacenamiento local
       if (typeof window !== 'undefined') {
+        clearPaymentSession();
         localStorage.removeItem('auth');
       }
     },


### PR DESCRIPTION
## Summary
- import `clearPaymentSession` utility in auth slice
- invoke `clearPaymentSession()` during logout before removing auth from `localStorage`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 80 problems across repository)*

------
https://chatgpt.com/codex/tasks/task_e_689f62d862dc833383d4bd88ee785c68